### PR TITLE
Add tweet_id to TwitterAds::Creative::ScheduledPromotedTweet

### DIFF
--- a/lib/twitter-ads/creative/scheduled_promoted_tweet.rb
+++ b/lib/twitter-ads/creative/scheduled_promoted_tweet.rb
@@ -13,6 +13,7 @@ module TwitterAds
       attr_reader :account
 
       property :id, read_only: true
+      property :tweet_id, read_only: true
       property :created_at, type: :time, read_only: true
       property :updated_at, type: :time, read_only: true
       property :deleted, type: :bool, read_only: true


### PR DESCRIPTION
# Before

```
ad_account = MY_AD_ACCOUNT
TwitterAds::Creative::ScheduledPromotedTweet.all(ad_account).map {|t| t.tweet_id }
NoMethodError: undefined method `tweet_id' for #<TwitterAds::Creative::ScheduledPromotedTweet:0x0000XXXXXXXXXXXX>
```

# After

```
ad_account = MY_AD_ACCOUNT
TwitterAds::Creative::ScheduledPromotedTweet.all(ad_account).map {|t| t.tweet_id }
=> ["1000000000000000001", "1000000000000000002"]
```